### PR TITLE
Fixes missing header

### DIFF
--- a/lib/RawData_Legacy.cpp
+++ b/lib/RawData_Legacy.cpp
@@ -1,5 +1,6 @@
 #include <motioncam/RawData.hpp>
 #include <vector>
+#include <cstring>
 
 namespace motioncam {
     namespace raw {


### PR DESCRIPTION
```
motioncam-decoder/lib/RawData_Legacy.cpp:403:22: erreur: « memset » n'est pas un membre de « std »
std::memset(output, 0, sizeof(uint16_t)*BLOCK_SIZE);

```

Adding the cstring header fixes this issue.